### PR TITLE
Add user roles and admin dashboard

### DIFF
--- a/nextjs/src/app/api/admin/users/route.ts
+++ b/nextjs/src/app/api/admin/users/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createSSRSassClient } from '@/lib/supabase/server';
+import { createServerAdminClient } from '@/lib/supabase/serverAdminClient';
+
+async function isAdmin() {
+    const supabase = await createSSRSassClient();
+    const client = supabase.getSupabaseClient();
+    const { data: { user } } = await client.auth.getUser();
+    if (!user) return false;
+    const { data } = await client.from('user_roles').select('role').eq('id', user.id).single();
+    return data?.role === 'ROLE_ADMIN';
+}
+
+export async function GET() {
+    if (!(await isAdmin())) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+    const admin = await createServerAdminClient();
+    const { data, error } = await admin.auth.admin.listUsers();
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+    const users = await Promise.all(
+        data.users.map(async (u) => {
+            const { data: roleData } = await admin
+                .from('user_roles')
+                .select('role')
+                .eq('id', u.id)
+                .single();
+            return { id: u.id, email: u.email, role: roleData?.role ?? 'ROLE_USER' };
+        })
+    );
+
+    return NextResponse.json({ users });
+}
+
+export async function POST(req: NextRequest) {
+    if (!(await isAdmin())) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    const { email, password, role } = await req.json();
+    const admin = await createServerAdminClient();
+    const { data, error } = await admin.auth.admin.createUser({ email, password, email_confirm: true });
+    if (error || !data.user) return NextResponse.json({ error: error?.message || 'Error' }, { status: 400 });
+    await admin.from('user_roles').insert({ id: data.user.id, role: role || 'ROLE_USER' });
+    return NextResponse.json({ id: data.user.id });
+}
+
+export async function PUT(req: NextRequest) {
+    if (!(await isAdmin())) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    const { id, role } = await req.json();
+    const admin = await createServerAdminClient();
+    await admin.from('user_roles').update({ role }).eq('id', id);
+    return NextResponse.json({ success: true });
+}
+
+export async function DELETE(req: NextRequest) {
+    if (!(await isAdmin())) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    const { id } = await req.json();
+    const admin = await createServerAdminClient();
+    await admin.auth.admin.deleteUser(id);
+    return NextResponse.json({ success: true });
+}

--- a/nextjs/src/app/app/admin/page.tsx
+++ b/nextjs/src/app/app/admin/page.tsx
@@ -2,6 +2,11 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useGlobal } from '@/lib/context/GlobalContext';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
 
 interface UserRow {
     id: string;
@@ -17,6 +22,8 @@ export default function AdminUsersPage() {
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
     const [role, setRole] = useState('ROLE_USER');
+    const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+    const [userToDelete, setUserToDelete] = useState<UserRow | null>(null);
 
     useEffect(() => {
         if (user && user.role !== 'ROLE_ADMIN') {
@@ -63,53 +70,100 @@ export default function AdminUsersPage() {
         loadUsers();
     }
 
-    async function deleteUser(id: string) {
+    async function deleteUserConfirmed() {
+        if (!userToDelete) return;
         await fetch('/api/admin/users', {
             method: 'DELETE',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ id })
+            body: JSON.stringify({ id: userToDelete.id })
         });
+        setShowDeleteDialog(false);
+        setUserToDelete(null);
         loadUsers();
     }
 
     return (
         <div className="space-y-6 p-6">
-            <h1 className="text-2xl font-bold">User Management</h1>
-            {error && <p className="text-red-600">{error}</p>}
-            <form onSubmit={createUser} className="space-y-2">
-                <input className="border p-1" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
-                <input className="border p-1" type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
-                <select className="border p-1" value={role} onChange={e => setRole(e.target.value)}>
-                    <option value="ROLE_USER">ROLE_USER</option>
-                    <option value="ROLE_ADMIN">ROLE_ADMIN</option>
-                </select>
-                <button type="submit" className="border px-2 py-1">Create</button>
-            </form>
-            <table className="min-w-full text-sm">
-                <thead>
-                    <tr>
-                        <th className="border px-2">Email</th>
-                        <th className="border px-2">Role</th>
-                        <th className="border px-2">Actions</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {users.map(u => (
-                        <tr key={u.id}>
-                            <td className="border px-2">{u.email}</td>
-                            <td className="border px-2">
-                                <select value={u.role} onChange={e => updateRole(u.id, e.target.value)}>
-                                    <option value="ROLE_USER">ROLE_USER</option>
-                                    <option value="ROLE_ADMIN">ROLE_ADMIN</option>
-                                </select>
-                            </td>
-                            <td className="border px-2">
-                                <button onClick={() => deleteUser(u.id)} className="text-red-600">Delete</button>
-                            </td>
-                        </tr>
-                    ))}
-                </tbody>
-            </table>
+            <Card>
+                <CardHeader>
+                    <CardTitle>User Management</CardTitle>
+                    <CardDescription>Manage users and their roles</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {error && (
+                        <Alert variant="destructive" className="mb-6">
+                            <AlertDescription>{error}</AlertDescription>
+                        </Alert>
+                    )}
+                    <form onSubmit={createUser} className="flex flex-col md:flex-row gap-2 mb-6">
+                        <Input value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" type="email" required />
+                        <Input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" required />
+                        <select className="border rounded-md px-3 py-2 text-base md:text-sm" value={role} onChange={e => setRole(e.target.value)}>
+                            <option value="ROLE_USER">ROLE_USER</option>
+                            <option value="ROLE_ADMIN">ROLE_ADMIN</option>
+                        </select>
+                        <Button type="submit">Create</Button>
+                    </form>
+                    <div className="overflow-x-auto">
+                        <table className="min-w-full text-sm border rounded-lg overflow-hidden">
+                            <thead className="bg-muted">
+                                <tr>
+                                    <th className="px-4 py-2 text-left font-semibold">Email</th>
+                                    <th className="px-4 py-2 text-left font-semibold">Role</th>
+                                    <th className="px-4 py-2 text-left font-semibold">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {users.map(u => (
+                                    <tr key={u.id} className="border-b last:border-b-0">
+                                        <td className="px-4 py-2">{u.email}</td>
+                                        <td className="px-4 py-2">
+                                            <select
+                                                className="border rounded-md px-2 py-1 text-sm"
+                                                value={u.role}
+                                                onChange={e => updateRole(u.id, e.target.value)}
+                                            >
+                                                <option value="ROLE_USER">ROLE_USER</option>
+                                                <option value="ROLE_ADMIN">ROLE_ADMIN</option>
+                                            </select>
+                                        </td>
+                                        <td className="px-4 py-2">
+                                            <Button
+                                                type="button"
+                                                variant="destructive"
+                                                size="sm"
+                                                onClick={() => {
+                                                    setUserToDelete(u);
+                                                    setShowDeleteDialog(true);
+                                                }}
+                                            >
+                                                Delete
+                                            </Button>
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </CardContent>
+            </Card>
+            {/* Delete Confirmation Dialog */}
+            <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete User</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            Are you sure you want to delete this user? This action cannot be undone.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={deleteUserConfirmed} className="bg-red-600 hover:bg-red-700">
+                            Delete
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 }

--- a/nextjs/src/app/app/admin/page.tsx
+++ b/nextjs/src/app/app/admin/page.tsx
@@ -1,0 +1,115 @@
+"use client";
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useGlobal } from '@/lib/context/GlobalContext';
+
+interface UserRow {
+    id: string;
+    email: string;
+    role: string;
+}
+
+export default function AdminUsersPage() {
+    const { user } = useGlobal();
+    const router = useRouter();
+    const [users, setUsers] = useState<UserRow[]>([]);
+    const [error, setError] = useState('');
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [role, setRole] = useState('ROLE_USER');
+
+    useEffect(() => {
+        if (user && user.role !== 'ROLE_ADMIN') {
+            router.push('/app');
+        }
+        loadUsers();
+    }, [user]);
+
+    async function loadUsers() {
+        const res = await fetch('/api/admin/users');
+        if (!res.ok) {
+            const data = await res.json();
+            setError(data.error || 'Failed to load');
+            return;
+        }
+        const data = await res.json();
+        setUsers(data.users);
+    }
+
+    async function createUser(e: React.FormEvent) {
+        e.preventDefault();
+        const res = await fetch('/api/admin/users', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email, password, role })
+        });
+        if (!res.ok) {
+            const d = await res.json();
+            setError(d.error || 'Failed');
+        } else {
+            setEmail('');
+            setPassword('');
+            setRole('ROLE_USER');
+            loadUsers();
+        }
+    }
+
+    async function updateRole(id: string, role: string) {
+        await fetch('/api/admin/users', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id, role })
+        });
+        loadUsers();
+    }
+
+    async function deleteUser(id: string) {
+        await fetch('/api/admin/users', {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id })
+        });
+        loadUsers();
+    }
+
+    return (
+        <div className="space-y-6 p-6">
+            <h1 className="text-2xl font-bold">User Management</h1>
+            {error && <p className="text-red-600">{error}</p>}
+            <form onSubmit={createUser} className="space-y-2">
+                <input className="border p-1" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+                <input className="border p-1" type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+                <select className="border p-1" value={role} onChange={e => setRole(e.target.value)}>
+                    <option value="ROLE_USER">ROLE_USER</option>
+                    <option value="ROLE_ADMIN">ROLE_ADMIN</option>
+                </select>
+                <button type="submit" className="border px-2 py-1">Create</button>
+            </form>
+            <table className="min-w-full text-sm">
+                <thead>
+                    <tr>
+                        <th className="border px-2">Email</th>
+                        <th className="border px-2">Role</th>
+                        <th className="border px-2">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {users.map(u => (
+                        <tr key={u.id}>
+                            <td className="border px-2">{u.email}</td>
+                            <td className="border px-2">
+                                <select value={u.role} onChange={e => updateRole(u.id, e.target.value)}>
+                                    <option value="ROLE_USER">ROLE_USER</option>
+                                    <option value="ROLE_ADMIN">ROLE_ADMIN</option>
+                                </select>
+                            </td>
+                            <td className="border px-2">
+                                <button onClick={() => deleteUser(u.id)} className="text-red-600">Delete</button>
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/nextjs/src/components/AppLayout.tsx
+++ b/nextjs/src/components/AppLayout.tsx
@@ -45,12 +45,17 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
 
     const productName = process.env.NEXT_PUBLIC_PRODUCTNAME;
 
-    const navigation = [
+    const baseNavigation = [
         { name: 'Inicio', href: '/app', icon: Home },
         { name: 'Archivos', href: '/app/storage', icon: Files },
         { name: 'Tareas', href: '/app/table', icon: LucideListTodo },
         { name: 'Configuración', href: '/app/user-settings', icon: User },
     ];
+
+    const navigation = [...baseNavigation];
+    if (user?.role === 'ROLE_ADMIN') {
+        navigation.splice(3, 0, { name: 'Admin', href: '/app/admin', icon: User });
+    }
 
     const toggleSidebar = () => setSidebarOpen(!isSidebarOpen);
 

--- a/nextjs/src/lib/context/GlobalContext.tsx
+++ b/nextjs/src/lib/context/GlobalContext.tsx
@@ -9,18 +9,19 @@ type User = {
     email: string;
     id: string;
     registered_at: Date;
+    role: string;
 };
 
 interface GlobalContextType {
     loading: boolean;
-    user: User | null;  // Add this
+    user: User | null;
 }
 
 const GlobalContext = createContext<GlobalContextType | undefined>(undefined);
 
 export function GlobalProvider({ children }: { children: React.ReactNode }) {
     const [loading, setLoading] = useState(true);
-    const [user, setUser] = useState<User | null>(null);  // Add this
+    const [user, setUser] = useState<User | null>(null);
 
     useEffect(() => {
         async function loadData() {
@@ -31,10 +32,17 @@ export function GlobalProvider({ children }: { children: React.ReactNode }) {
                 // Get user data
                 const { data: { user } } = await client.auth.getUser();
                 if (user) {
+                    const { data: roleData } = await client
+                        .from('user_roles')
+                        .select('role')
+                        .eq('id', user.id)
+                        .single();
+
                     setUser({
                         email: user.email!,
                         id: user.id,
-                        registered_at: new Date(user.created_at)
+                        registered_at: new Date(user.created_at),
+                        role: roleData?.role ?? 'ROLE_USER'
                     });
                 } else {
                     throw new Error('User not found');

--- a/nextjs/src/lib/types.ts
+++ b/nextjs/src/lib/types.ts
@@ -67,6 +67,31 @@ export type Database = {
         }
         Relationships: []
       }
+      user_roles: {
+        Row: {
+          id: string
+          role: string
+          created_at: string
+        }
+        Insert: {
+          id: string
+          role?: string
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          role?: string
+          created_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_roles_id_fkey"
+            columns: ["id"]
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
     }
     Views: {
       [_ in never]: never

--- a/supabase/migrations/20250703181500_user_roles.sql
+++ b/supabase/migrations/20250703181500_user_roles.sql
@@ -6,14 +6,28 @@ create table "public"."user_roles" (
 
 alter table "public"."user_roles" enable row level security;
 
+grant delete on table "public"."user_roles" to "service_role";
+grant insert on table "public"."user_roles" to "service_role";
+grant references on table "public"."user_roles" to "service_role";
+grant select on table "public"."user_roles" to "service_role";
+grant trigger on table "public"."user_roles" to "service_role";
+grant truncate on table "public"."user_roles" to "service_role";
+grant update on table "public"."user_roles" to "service_role";
+
 create policy "Users can view own role" on "public"."user_roles"
     for select using (auth.uid() = id);
 
 create policy "Users can insert own role" on "public"."user_roles"
     for insert with check (auth.uid() = id);
 
+create policy "Service can insert role" on "public"."user_roles"
+    for insert to service_role with check (true);
+
 create function public.handle_new_user()
-returns trigger language plpgsql as $$
+returns trigger
+language plpgsql
+security definer
+as $$
 begin
   insert into public.user_roles(id) values(new.id);
   return new;

--- a/supabase/migrations/20250703181500_user_roles.sql
+++ b/supabase/migrations/20250703181500_user_roles.sql
@@ -1,0 +1,25 @@
+create table "public"."user_roles" (
+    id uuid primary key references auth.users(id) on delete cascade,
+    role text not null default 'ROLE_USER',
+    created_at timestamp with time zone not null default now()
+);
+
+alter table "public"."user_roles" enable row level security;
+
+create policy "Users can view own role" on "public"."user_roles"
+    for select using (auth.uid() = id);
+
+create policy "Users can insert own role" on "public"."user_roles"
+    for insert with check (auth.uid() = id);
+
+create function public.handle_new_user()
+returns trigger language plpgsql as $$
+begin
+  insert into public.user_roles(id) values(new.id);
+  return new;
+end;
+$$;
+
+create trigger on_auth_user_created
+after insert on auth.users
+for each row execute procedure public.handle_new_user();


### PR DESCRIPTION
## Summary
- add `user_roles` table and triggers
- expose user role in context
- show Admin menu for admin users
- implement API endpoints to manage users
- add Admin UI for CRUD operations

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6866c6c2d64c832a86ebc050b3f4ba42